### PR TITLE
Cleaner require namespacing

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -5,7 +5,7 @@
 const args = require('yargs').argv._;
 const usabilla = require('../dist');
 
-const api = new usabilla.Usabilla(args[0], args[1]);
+const api = new usabilla(args[0], args[1]);
 
 // Get all buttons for this account.
 api.websites.buttons.get().then((response) => {

--- a/src/index.js
+++ b/src/index.js
@@ -364,7 +364,7 @@ class SignatureFactory {
  * The main Usabilla API object, which exposes product specific resources.
  * Needs to be instantiated with access and secret keys.
  */
-export class Usabilla {
+class Usabilla {
 
   constructor (accessKey, secretKey) {
     this.config = {
@@ -384,3 +384,5 @@ export class Usabilla {
     assign(this.config, options);
   }
 }
+
+module.exports = Usabilla;


### PR DESCRIPTION
Less verbose require namespacing: `new usabilla.Usabilla()` now just `new usabilla()`.

Cannot use ES6 `export default` because of [known Babel interoperability issues](http://www.2ality.com/2015/12/babel-commonjs.html) 