### PR TITLE
update headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usabilla-api",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Node client for Usabilla public API",
   "main": "./dist/index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usabilla-api",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.1",
   "description": "Node client for Usabilla public API",
   "main": "./dist/index.js",
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -267,12 +267,8 @@ class SignatureFactory {
   }
 
   canonicalString () {
-
     // CanonicalHeaders
-    let CanonicalHeaders = [
-      `host:${this.host}\n`,
-      `x-usbl-date:${this.dates.longdate}\n`
-    ].join('');
+    let canonicalHeaders = `host:${this.host}\n` + `x-usbl-date:${this.dates.longdate}\n`;
 
     return [
       this.method || 'GET',     // HTTPRequestMethod

--- a/src/index.js
+++ b/src/index.js
@@ -262,30 +262,18 @@ class SignatureFactory {
     this.method = method;
   }
 
-  getCanonicalHeaders () {
-    return {
-      date: `date:${this.dates.usbldate}`,
-      host: `host:${this.host}\n`
-    };
-  }
-
   hash (string, encoding) {
     return crypto.createHash('sha256').update(string, 'utf8').digest(encoding);
   }
 
   canonicalString () {
-    const queryStr = this.queryParameters;
-    const bodyHash = this.hash('', 'hex');
-    const canonicalHeaders = this.getCanonicalHeaders();
-
     return [
-      this.method || 'GET',
-      this.url,
-      queryStr,
-      canonicalHeaders.date,
-      canonicalHeaders.host,
-      'date;host',
-      bodyHash
+      this.method || 'GET',               // HTTPRequestMethod
+      this.url,                           // CanonicalURI
+      this.queryParameters,               // CanonicalQueryString
+      `host:${this.host}`+ '\n' + `x-usbl-date:${this.dates.longdate}`+ '\n', // CanonicalHeaders
+      'host;x-usbl-date',                 // SignedHeaders
+      this.hash('', 'hex')                // HexEncode(Hash(RequestPayload))
     ].join('\n');
   };
 
@@ -295,10 +283,10 @@ class SignatureFactory {
 
   stringToSign () {
     return [
-      'USBL1-HMAC-SHA256',
-      this.dates.longdate,
-      this.dates.shortdate + '/' + 'usbl1_request',
-      this.hash(this.canonicalString(), 'hex')
+      'USBL1-HMAC-SHA256',                          // Algorithm
+      this.dates.longdate,                          // RequestDate
+      this.dates.shortdate + '/' + 'usbl1_request', // CredentialScope
+      this.hash(this.canonicalString(), 'hex')      // HashedCanonicalRequest
     ].join('\n');
   };
 
@@ -312,7 +300,7 @@ class SignatureFactory {
   authHeader () {
     return [
       'USBL1-HMAC-SHA256 Credential=' + this.accessKey + '/' + this.dates.shortdate + '/' + 'usbl1_request',
-      'SignedHeaders=' + 'date;host',
+      'SignedHeaders=' + 'host;x-usbl-date',
       'Signature=' + this.getSignature()
     ].join(', ');
   };
@@ -356,8 +344,8 @@ class SignatureFactory {
   sign () {
     this.dates = this.getDateTime();
     this.headers = {};
-    this.headers.date = this.dates.usbldate;
-    this.headers.Authorization = this.authHeader();
+    this.headers['Authorization'] = this.authHeader();
+    this.headers['x-usbl-date'] = this.dates.longdate;
 
     const response = {
       headers: this.headers,

--- a/src/index.js
+++ b/src/index.js
@@ -267,13 +267,20 @@ class SignatureFactory {
   }
 
   canonicalString () {
+
+    // CanonicalHeaders
+    CanonicalHeaders = [
+      `host:${this.host}\n`,
+      `x-usbl-date:${this.dates.longdate}\n`
+    ].join('');
+
     return [
-      this.method || 'GET',               // HTTPRequestMethod
-      this.url,                           // CanonicalURI
-      this.queryParameters,               // CanonicalQueryString
-      `host:${this.host}`+ '\n' + `x-usbl-date:${this.dates.longdate}`+ '\n', // CanonicalHeaders
-      'host;x-usbl-date',                 // SignedHeaders
-      this.hash('', 'hex')                // HexEncode(Hash(RequestPayload))
+      this.method || 'GET',     // HTTPRequestMethod
+      this.url,                 // CanonicalURI
+      this.queryParameters,     // CanonicalQueryString
+      CanonicalHeaders          // CanonicalHeaders
+      'host;x-usbl-date',       // SignedHeaders
+      this.hash('', 'hex')      // HexEncode(Hash(RequestPayload))
     ].join('\n');
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -269,7 +269,7 @@ class SignatureFactory {
   canonicalString () {
 
     // CanonicalHeaders
-    CanonicalHeaders = [
+    let CanonicalHeaders = [
       `host:${this.host}\n`,
       `x-usbl-date:${this.dates.longdate}\n`
     ].join('');
@@ -278,7 +278,7 @@ class SignatureFactory {
       this.method || 'GET',     // HTTPRequestMethod
       this.url,                 // CanonicalURI
       this.queryParameters,     // CanonicalQueryString
-      CanonicalHeaders          // CanonicalHeaders
+      CanonicalHeaders,         // CanonicalHeaders
       'host;x-usbl-date',       // SignedHeaders
       this.hash('', 'hex')      // HexEncode(Hash(RequestPayload))
     ].join('\n');

--- a/src/index.js
+++ b/src/index.js
@@ -274,7 +274,7 @@ class SignatureFactory {
       this.method || 'GET',     // HTTPRequestMethod
       this.url,                 // CanonicalURI
       this.queryParameters,     // CanonicalQueryString
-      CanonicalHeaders,         // CanonicalHeaders
+      canonicalHeaders,         // CanonicalHeaders
       'host;x-usbl-date',       // SignedHeaders
       this.hash('', 'hex')      // HexEncode(Hash(RequestPayload))
     ].join('\n');


### PR DESCRIPTION
XHRs with 'Date' header are not allowed by W3.org > moving to x-usbl-date

Reviewers: @usabilla/feds @usabilla/plumbers 

### Changelog:
- Date header to x-usbl-date header

### Notes for Testing:
- _None_ 
