### PR TITLE
error handling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,9 @@ class Resource {
 
         res.on('end', () => {
           answer = JSON.parse(str);
+          if (answer.error) {
+            reject(answer.error);
+          }
           _results = _results.concat(answer.items);
 
           if (answer.hasMore && this.config.iterator) {


### PR DESCRIPTION
The Usabilla API sometimes returns errors without a 500. We need to validate and reject for this.

Reviewers: @usabilla/feds @usabilla/plumbers 

### Change log:
- add reject for api error messages

### Notes for Testing:
- test with wrong credentials
