### PR TITLE
Include src in the npm distribution so third party bundling is enabled

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,2 @@
-src
 coverage
 .idea

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,9 +12,9 @@ const paths = {
 
 gulp.task('build', () => {
   return browserify(paths.entry, {
-      builtins: false,
-      standalone: 'usabilla-api',
-    })
+    builtins: false,
+    standalone: 'usabilla-api',
+  })
     .transform(babelify)
     .bundle()
     .pipe(source(paths.filename))

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./src/index');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "usabilla-api",
   "version": "1.0.1",
   "description": "Node client for Usabilla public API",
-  "main": "./dist/index.js",
+  "main": "index.js",
   "devDependencies": {
     "babel-core": "^6.21.0",
     "babel-polyfill": "^6.20.0",


### PR DESCRIPTION
The distribution will work for node and for third party bundling (using browserify/webpack) but it will not work for browsers yet.