### PR TITLE
change user agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usabilla-api",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Node client for Usabilla public API",
   "main": "index.js",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usabilla-api",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "description": "Node client for Usabilla public API",
   "main": "index.js",
   "devDependencies": {

--- a/src/resources/resource.js
+++ b/src/resources/resource.js
@@ -64,7 +64,7 @@ class Resource {
     this._results = results || [];
 
     this.signatureFactory.setUrl(this.url);
-    this.signatureFactory.setHeaders({'x-ub-api-client': `Usabilla API Node Client/${packageJson.version}`});
+    this.signatureFactory.setHeaders(Resource.getDefaultHeaders(packageJson.version));
     this.signatureFactory.handleQuery(this._query);
     const signature = this.signatureFactory.sign();
 
@@ -85,6 +85,12 @@ class Resource {
         res.on('end', this.handleOnEnd.bind(this, resolve, reject));
       }).on('error', this.handleOnError.bind(this, reject));
     });
+  }
+
+  static getDefaultHeaders(version) {
+    return {
+      'x-ub-api-client': `Usabilla API Node Client/${version}`
+    };
   }
 }
 

--- a/src/resources/resource.js
+++ b/src/resources/resource.js
@@ -64,7 +64,7 @@ class Resource {
     this._results = results || [];
 
     this.signatureFactory.setUrl(this.url);
-    this.signatureFactory.setHeaders({'user-agent': `Usabilla API Node Client/${packageJson.version}`});
+    this.signatureFactory.setHeaders({'x-ub-api-client': `Usabilla API Node Client/${packageJson.version}`});
     this.signatureFactory.handleQuery(this._query);
     const signature = this.signatureFactory.sign();
 

--- a/test/resources/resource.spec.js
+++ b/test/resources/resource.spec.js
@@ -94,4 +94,14 @@ describe('Resource', function() {
       expect(requestArgs.headers).toBe('bar');
     });
   });
+
+  describe('getDefaultHeaders', function() {
+    it('returns the proper default headers', function() {
+      const headers = Resource.getDefaultHeaders('1.0.0');
+
+      expect(headers).toEqual({
+        'x-ub-api-client': 'Usabilla API Node Client/1.0.0'
+      });
+    });
+  });
 });


### PR DESCRIPTION
Chrome overwrites the user agent string, which makes the signature fail. Moving to different namespace.