### PR TITLE
ci(circle): Force the use of the NPM registry

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,8 @@ machine:
     version: $(cat $HOME/$CIRCLE_PROJECT_REPONAME/.nvmrc)
 
 dependencies:
+  pre:
+    - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
   override:
     - yarn install
 
@@ -14,4 +16,4 @@ deployment:
   release:
     branch: master
     commands:
-      - DEBUG=condition yarn semantic-release || true
+      - DEBUG=condition npm run semantic-release || true


### PR DESCRIPTION
After experiencing some hard to debug authentication issues during the
automatic release of the package, an issue was found were the `yarn`
command uses a different registry than the `npm` command.

By forcing the storage of the `NPM_TOKEN` in the .npmrc and also using
the `npm` command for the semanic release, it is hopefully possible to
automatically release again.